### PR TITLE
Update 'testRepository.ref' for new Ubuntu releases

### DIFF
--- a/test/testRepository.ref
+++ b/test/testRepository.ref
@@ -96,36 +96,6 @@ INFO     apt_repos.Repository: Scanning Repository 'Testing Option Scan==True' (
   Results for 'ubuntu', '':
     Architectures: ['i386', 'amd64']
     DebSrc: True
-    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful main restricted universe multiverse
-    Suite: ubuntu:artful
-    Tags: []
-    TrustedGPG: ./gpg/ubuntu.gpg
-    Architectures: ['i386', 'amd64']
-    DebSrc: True
-    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful-backports main restricted universe multiverse
-    Suite: ubuntu:artful-backports
-    Tags: []
-    TrustedGPG: ./gpg/ubuntu.gpg
-    Architectures: ['i386', 'amd64']
-    DebSrc: True
-    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful-proposed main restricted universe multiverse
-    Suite: ubuntu:artful-proposed
-    Tags: []
-    TrustedGPG: ./gpg/ubuntu.gpg
-    Architectures: ['i386', 'amd64']
-    DebSrc: True
-    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful-security main restricted universe multiverse
-    Suite: ubuntu:artful-security
-    Tags: []
-    TrustedGPG: ./gpg/ubuntu.gpg
-    Architectures: ['i386', 'amd64']
-    DebSrc: True
-    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful-updates main restricted universe multiverse
-    Suite: ubuntu:artful-updates
-    Tags: []
-    TrustedGPG: ./gpg/ubuntu.gpg
-    Architectures: ['i386', 'amd64']
-    DebSrc: True
     SourcesList: deb http://archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse
     Suite: ubuntu:bionic
     Tags: []
@@ -187,31 +157,31 @@ INFO     apt_repos.Repository: Scanning Repository 'Testing Option Scan==True' (
     Architectures: ['i386', 'amd64']
     DebSrc: True
     SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel main restricted universe multiverse
-    Suite: ubuntu:disco
+    Suite: ubuntu:eoan
     Tags: []
     TrustedGPG: ./gpg/ubuntu.gpg
     Architectures: ['i386', 'amd64']
     DebSrc: True
     SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel-backports main restricted universe multiverse
-    Suite: ubuntu:disco-backports
+    Suite: ubuntu:eoan-backports
     Tags: []
     TrustedGPG: ./gpg/ubuntu.gpg
     Architectures: ['i386', 'amd64']
     DebSrc: True
     SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel-proposed main restricted universe multiverse
-    Suite: ubuntu:disco-proposed
+    Suite: ubuntu:eoan-proposed
     Tags: []
     TrustedGPG: ./gpg/ubuntu.gpg
     Architectures: ['i386', 'amd64']
     DebSrc: True
     SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel-security main restricted universe multiverse
-    Suite: ubuntu:disco-security
+    Suite: ubuntu:eoan-security
     Tags: []
     TrustedGPG: ./gpg/ubuntu.gpg
     Architectures: ['i386', 'amd64']
     DebSrc: True
     SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel-updates main restricted universe multiverse
-    Suite: ubuntu:disco-updates
+    Suite: ubuntu:eoan-updates
     Tags: []
     TrustedGPG: ./gpg/ubuntu.gpg
     Architectures: ['i386', 'amd64']
@@ -242,6 +212,36 @@ INFO     apt_repos.Repository: Scanning Repository 'Testing Option Scan==True' (
     DebSrc: True
     SourcesList: deb http://archive.ubuntu.com/ubuntu/ disco-updates main restricted universe multiverse
     Suite: ubuntu:disco-updates
+    Tags: []
+    TrustedGPG: ./gpg/ubuntu.gpg
+    Architectures: ['i386', 'amd64']
+    DebSrc: True
+    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan main restricted universe multiverse
+    Suite: ubuntu:eoan
+    Tags: []
+    TrustedGPG: ./gpg/ubuntu.gpg
+    Architectures: ['i386', 'amd64']
+    DebSrc: True
+    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan-backports main restricted universe multiverse
+    Suite: ubuntu:eoan-backports
+    Tags: []
+    TrustedGPG: ./gpg/ubuntu.gpg
+    Architectures: ['i386', 'amd64']
+    DebSrc: True
+    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan-proposed main restricted universe multiverse
+    Suite: ubuntu:eoan-proposed
+    Tags: []
+    TrustedGPG: ./gpg/ubuntu.gpg
+    Architectures: ['i386', 'amd64']
+    DebSrc: True
+    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan-security main restricted universe multiverse
+    Suite: ubuntu:eoan-security
+    Tags: []
+    TrustedGPG: ./gpg/ubuntu.gpg
+    Architectures: ['i386', 'amd64']
+    DebSrc: True
+    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan-updates main restricted universe multiverse
+    Suite: ubuntu:eoan-updates
     Tags: []
     TrustedGPG: ./gpg/ubuntu.gpg
     Architectures: ['i386', 'amd64']


### PR DESCRIPTION
This fixes the following test failure I currently get on debian testing/bullseye (should be the same on Ubuntu, but I didn't check explicitly):

~~~
       [...]
        ----------------------------------------------------------
        Testing testRepository
        ----------------------------------------------------------
        --- testRepository.ref  2019-07-19 21:28:41.000000000 +0000
        +++ testRepository.res  2019-07-19 21:35:43.119296125 +0000
        @@ -96,36 +96,6 @@
           Results for 'ubuntu', '':
             Architectures: ['i386', 'amd64']
             DebSrc: True
        -    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful main restricted universe multiverse
        -    Suite: ubuntu:artful
        -    Tags: []
        -    TrustedGPG: ./gpg/ubuntu.gpg
        -    Architectures: ['i386', 'amd64']
        -    DebSrc: True
        -    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful-backports main restricted universe multiverse
        -    Suite: ubuntu:artful-backports
        -    Tags: []
        -    TrustedGPG: ./gpg/ubuntu.gpg
        -    Architectures: ['i386', 'amd64']
        -    DebSrc: True
        -    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful-proposed main restricted universe multiverse
        -    Suite: ubuntu:artful-proposed
        -    Tags: []
        -    TrustedGPG: ./gpg/ubuntu.gpg
        -    Architectures: ['i386', 'amd64']
        -    DebSrc: True
        -    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful-security main restricted universe multiverse
        -    Suite: ubuntu:artful-security
        -    Tags: []
        -    TrustedGPG: ./gpg/ubuntu.gpg
        -    Architectures: ['i386', 'amd64']
        -    DebSrc: True
        -    SourcesList: deb http://archive.ubuntu.com/ubuntu/ artful-updates main restricted universe multiverse
        -    Suite: ubuntu:artful-updates
        -    Tags: []
        -    TrustedGPG: ./gpg/ubuntu.gpg
        -    Architectures: ['i386', 'amd64']
        -    DebSrc: True
             SourcesList: deb http://archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse
             Suite: ubuntu:bionic
             Tags: []
        @@ -187,31 +157,31 @@
             Architectures: ['i386', 'amd64']
             DebSrc: True
             SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel main restricted universe multiverse
        -    Suite: ubuntu:disco
        +    Suite: ubuntu:eoan
             Tags: []
             TrustedGPG: ./gpg/ubuntu.gpg
             Architectures: ['i386', 'amd64']
             DebSrc: True
             SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel-backports main restricted universe multiverse
        -    Suite: ubuntu:disco-backports
        +    Suite: ubuntu:eoan-backports
             Tags: []
             TrustedGPG: ./gpg/ubuntu.gpg
             Architectures: ['i386', 'amd64']
             DebSrc: True
             SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel-proposed main restricted universe multiverse
        -    Suite: ubuntu:disco-proposed
        +    Suite: ubuntu:eoan-proposed
             Tags: []
             TrustedGPG: ./gpg/ubuntu.gpg
             Architectures: ['i386', 'amd64']
             DebSrc: True
             SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel-security main restricted universe multiverse
        -    Suite: ubuntu:disco-security
        +    Suite: ubuntu:eoan-security
             Tags: []
             TrustedGPG: ./gpg/ubuntu.gpg
             Architectures: ['i386', 'amd64']
             DebSrc: True
             SourcesList: deb http://archive.ubuntu.com/ubuntu/ devel-updates main restricted universe multiverse
        -    Suite: ubuntu:disco-updates
        +    Suite: ubuntu:eoan-updates
             Tags: []
             TrustedGPG: ./gpg/ubuntu.gpg
             Architectures: ['i386', 'amd64']
        @@ -245,6 +215,36 @@
             Tags: []
             TrustedGPG: ./gpg/ubuntu.gpg
             Architectures: ['i386', 'amd64']
        +    DebSrc: True
        +    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan main restricted universe multiverse
        +    Suite: ubuntu:eoan
        +    Tags: []
        +    TrustedGPG: ./gpg/ubuntu.gpg
        +    Architectures: ['i386', 'amd64']
        +    DebSrc: True
        +    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan-backports main restricted universe multiverse
        +    Suite: ubuntu:eoan-backports
        +    Tags: []
        +    TrustedGPG: ./gpg/ubuntu.gpg
        +    Architectures: ['i386', 'amd64']
        +    DebSrc: True
        +    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan-proposed main restricted universe multiverse
        +    Suite: ubuntu:eoan-proposed
        +    Tags: []
        +    TrustedGPG: ./gpg/ubuntu.gpg
        +    Architectures: ['i386', 'amd64']
        +    DebSrc: True
        +    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan-security main restricted universe multiverse
        +    Suite: ubuntu:eoan-security
        +    Tags: []
        +    TrustedGPG: ./gpg/ubuntu.gpg
        +    Architectures: ['i386', 'amd64']
        +    DebSrc: True
        +    SourcesList: deb http://archive.ubuntu.com/ubuntu/ eoan-updates main restricted universe multiverse
        +    Suite: ubuntu:eoan-updates
        +    Tags: []
        +    TrustedGPG: ./gpg/ubuntu.gpg
        +    Architectures: ['i386', 'amd64']
             DebSrc: True
             SourcesList: deb http://archive.ubuntu.com/ubuntu/ precise main restricted universe multiverse
             Suite: ubuntu:precise
~~~