### PR TITLE
Drop 'encoding' keyword when loading json files, removed in Python 3.8

### DIFF
--- a/apt_repos/__init__.py
+++ b/apt_repos/__init__.py
@@ -204,12 +204,12 @@ def getSuites(selectors=None):
                     if str(filename).endswith(".suites"):
                         logger.debug("reading suites file " + filename)
                         with open(filename, 'r') as file:
-                            jsonData = json.load(file, encoding="utf-8")
+                            jsonData = json.load(file)
                             suitesData[f] = (jsonData, basedir)
                             configSectionsCount += len(jsonData)
                     elif str(filename).endswith(".repos"):
                         with open(filename, 'r') as file:
-                            jsonData = json.load(file, encoding="utf-8")
+                            jsonData = json.load(file)
                             reposData[f] = (jsonData, basedir)
                             configSectionsCount += len(jsonData)
                 except json.decoder.JSONDecodeError as ex:


### PR DESCRIPTION
Otherwise, running tests during the build with Python 3.9
fails like this:

    ----------------------------------------------------------
    Testing testSuiteSelectors
    ----------------------------------------------------------
    Traceback (most recent call last):
      File "/<<PKGBUILDDIR>>/test/./test_lib_apt_repos.py", line 326, in <module>
        main()
      File "/<<PKGBUILDDIR>>/test/./test_lib_apt_repos.py", line 320, in main
        globals()[method]()
      File "/<<PKGBUILDDIR>>/test/./test_lib_apt_repos.py", line 49, in testSuiteSelectors
        dumpSelectedSuites(apt_repos.getSuites(selector), selector)
      File "/<<PKGBUILDDIR>>/test/../apt_repos/__init__.py", line 212, in getSuites
        jsonData = json.load(file, encoding="utf-8")
      File "/usr/lib/python3.9/json/__init__.py", line 293, in load
        return loads(fp.read(),
      File "/usr/lib/python3.9/json/__init__.py", line 359, in loads
        return cls(**kw).decode(s)
    TypeError: __init__() got an unexpected keyword argument 'encoding'

It looks like the `encoding` keyword has been removed in newer Python
versions.

The documentation for `json.load` says [1]:

> Changed in version 3.6: fp can now be a binary file.
> The input encoding should be UTF-8, UTF-16 or UTF-32.

The doc for Python 3.7 `json.loads` method (i.e. an extra 's' at the
end of the method name) says:

> The other arguments have the same meaning as in load(), except encoding
> which is ignored and deprecated.

and for 3.8, the 'encoding' param for that method is gone.

This reverts commit e63e49d1ae59224172bf13dd7242a9cadd3a9489,
"using utf-8 encoding when loading json files".

[1] https://docs.python.org/3/library/json.html