### PR TITLE
Use /etc/apt/trusted.gpg.d/ for GPG key to support apt >= 2.4.0

### DIFF
--- a/apt_repos/RepoSuite.py
+++ b/apt_repos/RepoSuite.py
@@ -66,7 +66,7 @@ class RepoSuite:
 
 
         # create caching structure
-        dirs = [ "/etc/apt", "/var/lib/dpkg", "/var/cache/apt/archives/partial", "/var/lib/apt/lists/partial" ]
+        dirs = [ "/etc/apt/trusted.gpg.d", "/var/lib/dpkg", "/var/cache/apt/archives/partial", "/var/lib/apt/lists/partial" ]
         for dir in dirs:
             fullDir = self.rootdir + dir
             if not os.path.isdir(fullDir):
@@ -80,7 +80,7 @@ class RepoSuite:
         self._ensureFileContent(self.rootdir + "/etc/apt/sources.list", self.getSourcesList())
         self._ensureFileContent(self.rootdir + "/etc/apt/apt.conf", self.getAptConf())
         if self.trustedGPGFile:
-            self._ensureFileContent(self.rootdir + "/etc/apt/trusted.gpg", self.getTrustedGPG())
+            self._ensureFileContent(self.rootdir + "/etc/apt/trusted.gpg.d/apt-repos.gpg", self.getTrustedGPG())
         self._ensureFileContent(self.rootdir + "/var/lib/dpkg/status", "")
         
 


### PR DESCRIPTION
Use a file `apt-repos.gpg` inside of the `/etc/apt/trusted.gpg.d`
directory for the GPG keyring instead of the legacy
`/etc/apt/trusted.gpg`.

Related Debian NEWS entry:

> apt (2.4.0) unstable; urgency=medium
>
>   GPG verification now first tries only the trusted.gpg.d keys, before
>   then falling back to the legacy trusted.gpg keyring and issuing a
>   warning to migrate keys if verification succeeded in the fallback.
>
>  -- Julian Andres Klode <jak@debian.org>  Tue, 22 Feb 2022 20:01:00 +0100

In my case, on Debian testing with apt 2.4.1, no fallback was
automatically used and GPG verification just failed when
running `make tests` without this change in place.